### PR TITLE
Restore generated PDU helpers and adjust RPC usage

### DIFF
--- a/src/impl/CommunicationBuffer.js
+++ b/src/impl/CommunicationBuffer.js
@@ -1,5 +1,11 @@
 import { DataPacket } from './DataPacket.js';
 
+const RPC_CHANNEL_TEMP_PREFIX = '__rpc_channel__';
+
+function makeRpcChannelTempKey(channelId) {
+    return `${RPC_CHANNEL_TEMP_PREFIX}${channelId}`;
+}
+
 /**
  * Holds and manages the raw binary data for PDU channels and RPC packets.
  */
@@ -15,11 +21,21 @@ export class CommunicationBuffer {
          * @type {Map<string, Map<string, {buffer: ArrayBuffer, timestamp: number}>>}
          */
         this.buffers = new Map();
-        /** 
-         * @private 
+        /**
+         * @private
+         * @type {Map<string, Map<number, string>>}
+         */
+        this.rpc_channel_map = new Map();
+        /**
+         * @private
          * @type {Map<string, Map<string, ArrayBuffer>>}
          */
         this.rpc_buffers = new Map();
+        /**
+         * @private
+         * @type {Map<string, string[]>}
+         */
+        this.pending_rpc_clients = new Map();
     }
 
     /**
@@ -74,6 +90,17 @@ export class CommunicationBuffer {
     }
 
     /**
+     * Retrieves the original PDU name for a given robot/channel pair.
+     * @param {string} robotName
+     * @param {number} channelId
+     * @returns {string | null}
+     */
+    get_pdu_name(robotName, channelId) {
+        const info = this.pduConfig.getPduInfoByChannelId(robotName, channelId);
+        return info ? info.org_name : null;
+    }
+
+    /**
      * Retrieves the buffer for a given PDU and consumes it (removes it from the buffer).
      * @param {string} robotName 
      * @param {string} pduName 
@@ -103,10 +130,52 @@ export class CommunicationBuffer {
     }
 
     /**
-     * Stores an RPC packet.
-     * @param {string} serviceName 
-     * @param {string} clientName 
-     * @param {ArrayBuffer} packetData 
+     * Peeks at a buffer without consuming it.
+     * @param {string} robotName
+     * @param {string} pduName
+     * @returns {ArrayBuffer | undefined}
+     */
+    peek_buffer(robotName, pduName) {
+        return this.buffers.get(robotName)?.get(pduName)?.buffer;
+    }
+
+    /**
+     * Registers a mapping between RPC channel IDs and logical client names.
+     * @param {string} serviceName
+     * @param {number} channelId
+     * @param {string} clientName
+     */
+    register_rpc_channel(serviceName, channelId, clientName) {
+        if (!this.rpc_channel_map.has(serviceName)) {
+            this.rpc_channel_map.set(serviceName, new Map());
+        }
+        this.rpc_channel_map.get(serviceName).set(channelId, clientName);
+    }
+
+    register_pending_rpc(serviceName, clientName) {
+        if (!this.pending_rpc_clients.has(serviceName)) {
+            this.pending_rpc_clients.set(serviceName, []);
+        }
+        this.pending_rpc_clients.get(serviceName).push(clientName);
+    }
+
+    _consume_pending_rpc(serviceName) {
+        const queue = this.pending_rpc_clients.get(serviceName);
+        if (!queue || queue.length === 0) {
+            return null;
+        }
+        const name = queue.shift();
+        if (queue.length === 0) {
+            this.pending_rpc_clients.delete(serviceName);
+        }
+        return name;
+    }
+
+    /**
+     * Stores an RPC packet keyed by service/client name.
+     * @param {string} serviceName
+     * @param {string} clientName
+     * @param {ArrayBuffer} packetData
      */
     put_rpc_packet(serviceName, clientName, packetData) {
         if (!this.rpc_buffers.has(serviceName)) {
@@ -116,16 +185,68 @@ export class CommunicationBuffer {
     }
 
     /**
-     * Retrieves an RPC packet and removes it from the buffer.
-     * @param {string} serviceName 
-     * @param {string} clientName 
+     * Retrieves and removes an RPC packet.
+     * @param {string} serviceName
+     * @param {string} clientName
      * @returns {ArrayBuffer | undefined}
      */
     get_rpc_packet(serviceName, clientName) {
-        const packet = this.rpc_buffers.get(serviceName)?.get(clientName);
-        if (packet) {
-            this.rpc_buffers.get(serviceName).delete(clientName);
+        const serviceMap = this.rpc_buffers.get(serviceName);
+        if (!serviceMap) {
+            return undefined;
         }
-        return packet;
+        const data = serviceMap.get(clientName);
+        if (data) {
+            serviceMap.delete(clientName);
+            if (serviceMap.size === 0) {
+                this.rpc_buffers.delete(serviceName);
+            }
+        }
+        return data;
+    }
+
+    /**
+     * Checks if an RPC packet exists for the given service/client pair.
+     * @param {string} serviceName
+     * @param {string} clientName
+     * @returns {boolean}
+     */
+    has_rpc_packet(serviceName, clientName) {
+        return this.rpc_buffers.get(serviceName)?.has(clientName) ?? false;
+    }
+
+    /**
+     * Removes a registered RPC channel mapping.
+     * @param {string} serviceName
+     * @param {number} channelId
+     */
+    unregister_rpc_channel(serviceName, channelId) {
+        const serviceMap = this.rpc_channel_map.get(serviceName);
+        if (serviceMap) {
+            serviceMap.delete(channelId);
+            if (serviceMap.size === 0) {
+                this.rpc_channel_map.delete(serviceName);
+            }
+        }
+    }
+
+    /**
+     * Stores RPC payload data keyed by the registered channel mapping.
+     * @param {string} serviceName
+     * @param {number} channelId
+     * @param {ArrayBuffer} packetData
+     */
+    set_rpc_channel_buffer(serviceName, channelId, packetData) {
+        let clientName = this.rpc_channel_map.get(serviceName)?.get(channelId);
+        let fromRegisteredChannel = true;
+        if (!clientName) {
+            clientName = this._consume_pending_rpc(serviceName);
+            fromRegisteredChannel = false;
+        }
+        const targetKey = clientName ?? makeRpcChannelTempKey(channelId);
+        this.put_rpc_packet(serviceName, targetKey, packetData);
+        if (fromRegisteredChannel && clientName) {
+            this.set_buffer(serviceName, clientName, packetData);
+        }
     }
 }

--- a/src/impl/DataPacket.js
+++ b/src/impl/DataPacket.js
@@ -49,6 +49,22 @@ export class DataPacket {
         this.set_real_time_usec(0);
     }
 
+    /**
+     * Returns the raw PDU body payload.
+     * @returns {ArrayBuffer}
+     */
+    get_pdu_data() {
+        return this.body_data;
+    }
+
+    /**
+     * Replaces the packet body payload.
+     * @param {ArrayBuffer} data
+     */
+    set_pdu_data(data) {
+        this.body_data = data;
+    }
+
     set_hako_time_usec(time_usec) {
         this.meta_pdu.hako_time_us = time_usec;
     }

--- a/src/impl/WebSocketBaseCommunicationService.js
+++ b/src/impl/WebSocketBaseCommunicationService.js
@@ -1,7 +1,5 @@
 import { ICommunicationService } from './ICommunicationService.js';
 import { DataPacket, PDU_DATA, PDU_DATA_RPC_REQUEST, PDU_DATA_RPC_REPLY, DECLARE_PDU_FOR_READ, DECLARE_PDU_FOR_WRITE, REQUEST_PDU_READ, REGISTER_RPC_CLIENT } from './DataPacket.js';
-import { pduToJs_ServiceRequestHeader } from '../pdu_msgs/hako_srv_msgs/pdu_conv_ServiceRequestHeader.js';
-import { pduToJs_ServiceResponseHeader } from '../pdu_msgs/hako_srv_msgs/pdu_conv_ServiceResponseHeader.js';
 
 /**
  * Base class for WebSocket communication, containing common logic for clients and servers.
@@ -122,12 +120,8 @@ export class WebSocketBaseCommunicationService extends ICommunicationService {
                 if (this.data_handler) {
                     await this.data_handler(packet);
                 }
-            } else if (req_type === PDU_DATA_RPC_REQUEST) {
-                const header = pduToJs_ServiceRequestHeader(packet.get_pdu_data());
-                this.comm_buffer.put_rpc_packet(header.service_name, header.client_name, packet.get_pdu_data());
-            } else if (req_type === PDU_DATA_RPC_REPLY) {
-                const header = pduToJs_ServiceResponseHeader(packet.get_pdu_data());
-                this.comm_buffer.put_rpc_packet(header.service_name, header.client_name, packet.get_pdu_data());
+            } else if (req_type === PDU_DATA_RPC_REQUEST || req_type === PDU_DATA_RPC_REPLY) {
+                this.comm_buffer.set_rpc_channel_buffer(packet.robot_name, packet.channel_id, packet.get_pdu_data());
             } else if ([DECLARE_PDU_FOR_READ, DECLARE_PDU_FOR_WRITE, REQUEST_PDU_READ, REGISTER_RPC_CLIENT].includes(req_type)) {
                 if (this.handler) {
                     await this.handler(packet);

--- a/tests/RpcClient.test.js
+++ b/tests/RpcClient.test.js
@@ -7,10 +7,10 @@ import {
     WebSocketCommunicationService,
     WebSocketServerCommunicationService,
 } from '../src/index.js';
-import { createAddTwoIntsRequest } from '../src/pdu_msgs/hako_srv_msgs/pdu_jstype_AddTwoIntsRequest.js';
-import { createAddTwoIntsResponse } from '../src/pdu_msgs/hako_srv_msgs/pdu_jstype_AddTwoIntsResponse.js';
-import { js_to_pdu_AddTwoIntsRequest, pdu_to_js_AddTwoIntsRequest } from '../src/pdu_msgs/hako_srv_msgs/pdu_conv_AddTwoIntsRequest.js';
-import { pdu_to_js_AddTwoIntsResponse, js_to_pdu_AddTwoIntsResponse } from '../src/pdu_msgs/hako_srv_msgs/pdu_conv_AddTwoIntsResponse.js';
+import { AddTwoIntsRequest } from '../src/pdu_msgs/hako_srv_msgs/pdu_jstype_AddTwoIntsRequest.js';
+import { AddTwoIntsResponse } from '../src/pdu_msgs/hako_srv_msgs/pdu_jstype_AddTwoIntsResponse.js';
+import { jsToPdu_AddTwoIntsRequest, pduToJs_AddTwoIntsRequest } from '../src/pdu_msgs/hako_srv_msgs/pdu_conv_AddTwoIntsRequest.js';
+import { pduToJs_AddTwoIntsResponse, jsToPdu_AddTwoIntsResponse } from '../src/pdu_msgs/hako_srv_msgs/pdu_conv_AddTwoIntsResponse.js';
 import * as codes from '../src/rpc/codes.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -39,12 +39,12 @@ describe('RemotePduServiceClientManager and ServerManager RPC Calls', () => {
                     const [client_handle, raw_data] = serverPduManager.get_request();
                     
                     if (serviceName === 'Service/Add') {
-                        const req = pdu_to_js_AddTwoIntsRequest(raw_data);
+                        const req = pduToJs_AddTwoIntsRequest(raw_data);
                         console.log(`JS Server: AddTwoInts request: a=${req.a}, b=${req.b}`);
                         
-                        const res = createAddTwoIntsResponse();
+                        const res = new AddTwoIntsResponse();
                         res.sum = req.a + req.b;
-                        const response_pdu_data = js_to_pdu_AddTwoIntsResponse(res);
+                        const response_pdu_data = jsToPdu_AddTwoIntsResponse(res);
                         
                         await serverPduManager.put_response(client_handle, response_pdu_data);
                     }
@@ -80,10 +80,10 @@ describe('RemotePduServiceClientManager and ServerManager RPC Calls', () => {
     afterAll(async () => {
         console.log('Stopping JavaScript RPC test server...');
         serverLoopActive = false;
-        if (clientPduManager && clientPduManager.is_service_enabled()) {
+        if (clientPduManager) {
             await clientPduManager.stop_service();
         }
-        if (serverPduManager && serverPduManager.is_service_enabled()) {
+        if (serverPduManager) {
             await serverPduManager.stop_service();
         }
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -116,10 +116,10 @@ describe('RemotePduServiceClientManager and ServerManager RPC Calls', () => {
         expect(clientId.response_channel_id).toBe(1);
 
         // 3. Make RPC call
-        const req = createAddTwoIntsRequest();
-        req.a = 10;
-        req.b = 20;
-        const pduData = js_to_pdu_AddTwoIntsRequest(req);
+        const req = new AddTwoIntsRequest();
+        req.a = 10n;
+        req.b = 20n;
+        const pduData = jsToPdu_AddTwoIntsRequest(req);
 
         const callRequested = await clientPduManager.call_request(clientId, pduData, 5000);
         expect(callRequested).toBe(true);
@@ -142,8 +142,8 @@ describe('RemotePduServiceClientManager and ServerManager RPC Calls', () => {
         expect(responseRawData).not.toBeNull();
 
         // 5. Verify response
-        const res = pdu_to_js_AddTwoIntsResponse(responseRawData);
+        const res = pduToJs_AddTwoIntsResponse(responseRawData);
         expect(res).not.toBeNull();
-        expect(res.sum).toBe(30);
+        expect(res.sum).toBe(30n);
     }, 10000); // Increase timeout for this test
 });


### PR DESCRIPTION
## Summary
- restore the auto-generated hako_srv_msgs conversion and type modules to their original structure without custom helper aliases
- update the RemotePduServiceServerManager to instantiate RegisterClientResponsePacket directly and call the camelCase conversion helpers
- adjust the RPC integration test to use the generated classes/functions and compare BigInt fields correctly

## Testing
- npm test -- --detectOpenHandles

------
https://chatgpt.com/codex/tasks/task_e_68da40b2ce348322a53eab7f3bfc9c04