### PR TITLE
Ensure RpcProtocolClient test shuts down cleanly

### DIFF
--- a/tests/RpcProtocolClient.test.js
+++ b/tests/RpcProtocolClient.test.js
@@ -35,6 +35,7 @@ describe('RpcProtocolClient High-Level RPC Calls', () => {
     let serverPduManager;
     let serverCommService;
     let protocolServer;
+    let serverLoopPromise;
 
 
     // Server-side setup is the same as in RpcClient.test.js
@@ -65,7 +66,7 @@ describe('RpcProtocolClient High-Level RPC Calls', () => {
             pkg: 'hako_srv_msgs'
         });
         await protocolServer.startServices();
-        runServerLoop(protocolServer);
+        serverLoopPromise = runServerLoop(protocolServer);
         console.log('JavaScript High-Level RPC test server started.');
     });
 
@@ -73,6 +74,15 @@ describe('RpcProtocolClient High-Level RPC Calls', () => {
         console.log('Stopping JavaScript High-Level RPC test server...');
         if (protocolServer) {
             await protocolServer.stop();
+        }
+        if (serverLoopPromise) {
+            await serverLoopPromise;
+        }
+        if (serverPduManager) {
+            await serverPduManager.stop_service();
+        }
+        if (serverCommService) {
+            await serverCommService.stop_service();
         }
         await new Promise(resolve => setTimeout(resolve, 200));
     });


### PR DESCRIPTION
## Summary
- await the protocol server loop and stop WebSocket services in RpcProtocolClient.test.js
- ensure the high-level RPC test cleans up its resources to avoid lingering handles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db2a6074148322b8ce9b8e07cd082e